### PR TITLE
Updated issue with ACLRules not always being an array when trying to …

### DIFF
--- a/DscResources/NTFSAccessEntry/NTFSAccessEntry.psm1
+++ b/DscResources/NTFSAccessEntry/NTFSAccessEntry.psm1
@@ -117,6 +117,8 @@ Function Set-TargetResource
         $Force = $false
     )
 
+    $ACLRules = @()
+
     $inputPath = Get-InputPath($Path)
 
     if(Test-Path -Path $inputPath)
@@ -273,6 +275,8 @@ Function Test-TargetResource
         [bool]
         $Force = $false
     )
+
+    $ACLRules = @()
 
     $InDesiredState = $True
     $inputPath = Get-InputPath($Path)
@@ -598,7 +602,7 @@ Function Compare-NtfsRule
 
     foreach($refrenceObject in $Actual)
     {
-        $match = $Expected.Rules.Where({
+        $match = @($Expected.Rules).Where({
             (((($_.FileSystemRights.value__ -band $refrenceObject.FileSystemRights.value__) -match "$($_.FileSystemRights.value__)|$($refrenceObject.FileSystemRights.value__)") -and !$Force) -or ($_.FileSystemRights -eq $refrenceObject.FileSystemRights -and $Force)) -and
             $_.InheritanceFlags -eq $refrenceObject.InheritanceFlags -and
             $_.PropagationFlags -eq $refrenceObject.PropagationFlags -and

--- a/DscResources/RegistryAccessEntry/RegistryAccessEntry.psm1
+++ b/DscResources/RegistryAccessEntry/RegistryAccessEntry.psm1
@@ -113,6 +113,8 @@ Function Set-TargetResource
         $Force = $false
     )
 
+    $ACLRules = @()
+
     if(-not (Test-Path -Path $Path))
     {
         $errorMessage = $LocalizedData.ErrorPathNotFound -f $Path
@@ -235,6 +237,8 @@ Function Test-TargetResource
         [bool]
         $Force = $false
     )
+
+    $ACLRules = @()
 
     if(-not (Test-Path -Path $Path))
     {
@@ -384,7 +388,7 @@ Function Compare-RegistryRule
 
     foreach($refrenceObject in $Actual)
     {
-        $match = $Expected.Rules.Where({
+        $match = @($Expected.Rules).Where({
             $_.RegistryRights -eq $refrenceObject.RegistryRights -and
             $_.InheritanceFlags -eq $refrenceObject.InheritanceFlags -and
             $_.PropagationFlags -eq $refrenceObject.PropagationFlags -and


### PR DESCRIPTION
…add additional objects. Updated issue where Expected.Rules might only be a single object while trying to call a Where extension method.