### PR TITLE
Rights guid

### DIFF
--- a/DscResources/AccessControlResourceHelper/AccessControlResourceHelper.psm1
+++ b/DscResources/AccessControlResourceHelper/AccessControlResourceHelper.psm1
@@ -178,6 +178,7 @@ function Get-SchemaObjectName
     if($SchemaIdGuid)
     {
         $guidmap = @{}
+        $rootdse = Get-ADRootDSE
         Get-ADObject -SearchBase ($rootdse.SchemaNamingContext) -LDAPFilter "(schemaidguid=*)" -Properties Name,schemaIDGUID | 
             Foreach-Object -Process { $guidmap[$_.Name] = [System.GUID]$_.schemaIDGUID }
 

--- a/DscResources/AccessControlResourceHelper/AccessControlResourceHelper.psm1
+++ b/DscResources/AccessControlResourceHelper/AccessControlResourceHelper.psm1
@@ -177,6 +177,7 @@ function Get-SchemaObjectName
 
     if($SchemaIdGuid)
     {
+        $guidmap = @{}
         Get-ADObject -SearchBase ($rootdse.SchemaNamingContext) -LDAPFilter "(schemaidguid=*)" -Properties Name,schemaIDGUID | 
             Foreach-Object -Process { $guidmap[$_.Name] = [System.GUID]$_.schemaIDGUID }
 

--- a/DscResources/AccessControlResourceHelper/AccessControlResourceHelper.psm1
+++ b/DscResources/AccessControlResourceHelper/AccessControlResourceHelper.psm1
@@ -157,7 +157,7 @@ function Get-DelegationRightsGuid
         Get-ADObject -SearchBase ($rootdse.ConfigurationNamingContext) -LDAPFilter "(&(objectclass=controlAccessRight)(rightsguid=*))" -Properties Name,rightsGuid | 
             Foreach-Object -Process { $guidmap[$_.Name] = [System.GUID]$_.rightsGuid }
 
-        return $guidmap[$ObjectName]
+        return [system.guid]$guidmap[$ObjectName]
     }
     else
     {

--- a/DscResources/ActiveDirectoryAccessEntry/ActiveDirectoryAccessEntry.psm1
+++ b/DscResources/ActiveDirectoryAccessEntry/ActiveDirectoryAccessEntry.psm1
@@ -361,8 +361,8 @@ Function ConvertTo-ActiveDirectoryAccessRule
 
     foreach($ace in $AccessControlList.AccessControlEntry)
     {
-        $inheritedObjectType = Get-SchemaIdGuid -ObjectName $ace.InheritedObjectType
-        $objectType = Get-SchemaIdGuid -ObjectName $ace.ObjectType
+        $inheritedObjectType = Get-DelegationRightsGuid -ObjectName $ace.InheritedObjectType
+        $objectType = Get-DelegationRightsGuid -ObjectName $ace.ObjectType
         $rule = [PSCustomObject]@{
             Rules = New-Object System.DirectoryServices.ActiveDirectoryAccessRule($IdentityRef, $ace.ActiveDirectoryRights, $ace.AccessControlType, $objectType, $ace.InheritanceType, $inheritedObjectType)
             Ensure = $ace.Ensure

--- a/DscResources/ActiveDirectoryAuditRuleEntry/ActiveDirectoryAuditRuleEntry.psm1
+++ b/DscResources/ActiveDirectoryAuditRuleEntry/ActiveDirectoryAuditRuleEntry.psm1
@@ -406,7 +406,7 @@ Function ConvertTo-ActiveDirectoryAuditRule
 
     foreach($ace in $AccessControlList.AccessControlEntry)
     {
-        $InheritedObjectType = Get-SchemaIdGuid -ObjectName $ace.InheritedObjectType
+        $InheritedObjectType = Get-DelegationRightsGuid -ObjectName $ace.InheritedObjectType
         $rule = [PSCustomObject]@{
             Rules = New-Object System.DirectoryServices.ActiveDirectoryAuditRule($IdentityRef, $ace.ActiveDirectoryRights, $ace.AuditFlags, $ace.InheritanceType, $InheritedObjectType)
             Ensure = $ace.Ensure

--- a/Examples/ActiveDirectoryAccessEntry_example.ps1
+++ b/Examples/ActiveDirectoryAccessEntry_example.ps1
@@ -19,7 +19,7 @@ configuration Sample_ADAccessControl
                             InheritanceType = 'Descendents'
                             Ensure = 'Present'
                         }
-                    )               
+                    )
                 }
             )
         }
@@ -40,7 +40,7 @@ configuration Sample_ADAccessControl
                             InheritedObjectType = 'organizational-unit'
                             Ensure = 'Present'
                         }
-                    )               
+                    )
                 }
                 ActiveDirectoryAccessControlList
                 {
@@ -55,7 +55,7 @@ configuration Sample_ADAccessControl
                             ObjectType = 'computer'
                             Ensure = 'Present'
                         }
-                    )               
+                    )
                 }
             )
         }

--- a/Examples/ActiveDirectoryAccessEntry_example.ps1
+++ b/Examples/ActiveDirectoryAccessEntry_example.ps1
@@ -15,7 +15,7 @@ configuration Sample_ADAccessControl
                         ActiveDirectoryAccessRule
                         {
                             AccessControlType = 'Allow'
-                            ActiveDirectoryRights = 'FullControl'
+                            ActiveDirectoryRights = 'GenericAll'
                             InheritanceType = 'Descendents'
                             Ensure = 'Present'
                         }

--- a/Tests/Unit/ActiveDirectoryAccessEntry.Tests.ps1
+++ b/Tests/Unit/ActiveDirectoryAccessEntry.Tests.ps1
@@ -111,7 +111,7 @@ InModuleScope ActiveDirectoryAccessEntry {
         Mock -CommandName Test-Path -MockWith { return $true } -ModuleName $DSCResourceName
         Mock -CommandName Assert-Module -MockWith {} -ModuleName $DSCResourceName
         Mock -CommandName Import-Module -MockWith {} -ParameterFilter {$name -eq 'ActiveDirectory'}-ModuleName $DSCResourceName 
-        Mock -CommandName Get-SchemaIdGuid -MockWith { return [guid]"52ea1a9a-be7e-4213-9e69-5f28cb89b56a" } -ModuleName $DSCResourceName
+        Mock -CommandName Get-DelegationRightsGuid -MockWith { return [guid]"52ea1a9a-be7e-4213-9e69-5f28cb89b56a" } -ModuleName $DSCResourceName
         Mock -CommandName Get-SchemaObjectName -MockWith { return "Pwd-Last-Set" } -ModuleName $DSCResourceName
 
         Mock -CommandName Get-Acl -MockWith {
@@ -218,7 +218,7 @@ InModuleScope ActiveDirectoryAccessEntry {
         Mock -CommandName Test-Path -MockWith { return $true } -ModuleName $DSCResourceName
         Mock -CommandName Assert-Module -MockWith {} -ModuleName $DSCResourceName
         Mock -CommandName Import-Module -MockWith {} -ParameterFilter {$name -eq 'ActiveDirectory'} -ModuleName $DSCResourceName
-        Mock -CommandName Get-SchemaIdGuid -MockWith { return [guid]"52ea1a9a-be7e-4213-9e69-5f28cb89b56a" } -ModuleName $DSCResourceName
+        Mock -CommandName Get-DelegationRightsGuid -MockWith { return [guid]"52ea1a9a-be7e-4213-9e69-5f28cb89b56a" } -ModuleName $DSCResourceName
         Mock -CommandName Get-SchemaObjectName -MockWith { return "Pwd-Last-Set" } -ModuleName $DSCResourceName
 
         $identity = Resolve-Identity -Identity "Everyone"

--- a/Tests/Unit/ActiveDirectoryAuditRuleEntry.Tests.ps1
+++ b/Tests/Unit/ActiveDirectoryAuditRuleEntry.Tests.ps1
@@ -111,7 +111,7 @@ Import-Module "$($PSScriptRoot)\..\TestHelper.psm1" -Force
         Mock -CommandName Test-Path -MockWith { return $true } -ModuleName $DSCResourceName
         Mock -CommandName Assert-Module -MockWith {} -ModuleName $DSCResourceName
         Mock -CommandName Import-Module -MockWith {} -ParameterFilter {$Name -eq 'ActiveDirectory'}-ModuleName $DSCResourceName 
-        Mock -CommandName Get-SchemaIdGuid -MockWith { return [guid]"52ea1a9a-be7e-4213-9e69-5f28cb89b56a" } -ModuleName $DSCResourceName
+        Mock -CommandName Get-DelegationRightsGuid -MockWith { return [guid]"52ea1a9a-be7e-4213-9e69-5f28cb89b56a" } -ModuleName $DSCResourceName
         Mock -CommandName Get-SchemaObjectName -MockWith { return "Pwd-Last-Set" } -ModuleName $DSCResourceName
 
         Mock -CommandName Get-Acl -MockWith {
@@ -261,7 +261,7 @@ Import-Module "$($PSScriptRoot)\..\TestHelper.psm1" -Force
         Mock -CommandName Test-Path -MockWith { return $true } -ModuleName $DSCResourceName
         Mock -CommandName Assert-Module -MockWith {} -ModuleName $DSCResourceName
         Mock -CommandName Import-Module -MockWith {} -ParameterFilter {$Name -eq 'ActiveDirectory'} -ModuleName $DSCResourceName
-        Mock -CommandName Get-SchemaIdGuid -MockWith { return [guid]"52ea1a9a-be7e-4213-9e69-5f28cb89b56a" } -ModuleName $DSCResourceName
+        Mock -CommandName Get-DelegationRightsGuid -MockWith { return [guid]"52ea1a9a-be7e-4213-9e69-5f28cb89b56a" } -ModuleName $DSCResourceName
         Mock -CommandName Get-SchemaObjectName -MockWith { return "Pwd-Last-Set" } -ModuleName $DSCResourceName
 
         $Identity = Resolve-Identity -Identity "Everyone"


### PR DESCRIPTION
Refactored the helper function Get-SchemaIDGuid. Renamed to Get-DelegationRightsGuid.  The function will now do guid lookups on rightsGuids as well as SchemaIdGuids.
Also updated ActiveDirectoryEntry_Example.ps1 with a valid entry for the ActiveDirectoryRights parameter.