### PR TITLE
Changes RegistryAccessEntry to correctly remove specific ACEs from ACLs and gracefully handle the App Packages Principal, Issues #37 and #38

### DIFF
--- a/DscResources/RegistryAccessEntry/RegistryAccessEntry.psm1
+++ b/DscResources/RegistryAccessEntry/RegistryAccessEntry.psm1
@@ -218,12 +218,12 @@ Function Set-TargetResource
                 try
                 {
                     #If failure due to Identity translation issue then create the same rule with the identity as a sid to remove account
-                    $SIDRule = ConvertTo-SidIdentityRegistryAccessRule -Rule $Rule
-                    $currentAcl.AddAccessRule($Rule.Rule)
+                    $SIDRule = ConvertTo-SidIdentityRegistryAccessRule -Rule $Rule.Rule
+                    $currentAcl.AddAccessRule($SIDRule)
                 }
                 catch
                 {
-                    $message = $LocalizedData.AclNotFound -f $($Rule.IdentityReference.Value)
+                    $message = $LocalizedData.AclNotFound -f $($Rule.Rule.IdentityReference.Value)
                     Write-Verbose -Message $message
                 }
             }
@@ -546,14 +546,14 @@ function ConvertTo-SidIdentityRegistryAccessRule
 
     if ($Rule.IdentityReference.Value.Contains('\'))
     {
-        [System.Security.Principal.NTAccount]$PrinicipalName = $Rule.IdentityReference.Value.split('\')[1]
+        [System.Security.Principal.NTAccount]$Principal = $Rule.IdentityReference.Value.split('\')[1]
     }
     else
     {
-        [System.Security.Principal.NTAccount]$PrinicipalName = $Rule.IdentityReference.Value
+        [System.Security.Principal.NTAccount]$Principal = $Rule.IdentityReference.Value
     }
 
-    $SID = $PrinicipalName.Translate([System.Security.Principal.SecurityIdentifier])
+    $SID = $Principal.Translate([System.Security.Principal.SecurityIdentifier])
     $SIDRule = New-Object System.Security.AccessControl.RegistryAccessRule($SID, $Rule.RegistryRights.value__, $Rule.InheritanceFlags.value__, $Rule.PropagationFlags.value__, $Rule.AccessControlType.value__)
 
     return $SIDRule

--- a/DscResources/RegistryAccessEntry/RegistryAccessEntry.psm1
+++ b/DscResources/RegistryAccessEntry/RegistryAccessEntry.psm1
@@ -8,8 +8,8 @@ data LocalizedData
     # culture="en-US"
     ConvertFrom-StringData -StringData @'
         ErrorPathNotFound = The requested path "{0}" cannot be found.
-        AclNotFound = Error obtaining "{0}" ACL
-        AclFound = Obtained "{0}" ACL
+        AclNotFound       = Error obtaining "{0}" ACL
+        AclFound          = Obtained "{0}" ACL
         RemoveAccessError = "Unable to remove Access for "{0}"
 '@
 }

--- a/DscResources/RegistryAccessEntry/RegistryAccessEntry.psm1
+++ b/DscResources/RegistryAccessEntry/RegistryAccessEntry.psm1
@@ -1,6 +1,6 @@
 Import-Module -Name (Join-Path -Path ( Split-Path $PSScriptRoot -Parent ) `
         -ChildPath 'AccessControlResourceHelper\AccessControlResourceHelper.psm1') `
-    -Force
+        -Force
 
 # Localized messages
 data LocalizedData
@@ -53,10 +53,8 @@ Function Get-TargetResource
         foreach ($Principal in $AccessControlList)
         {
             $CimAccessControlEntries = New-Object -TypeName 'System.Collections.ObjectModel.Collection`1[Microsoft.Management.Infrastructure.CimInstance]'
-
             $PrincipalName = $Principal.Principal
             $ForcePrincipal = $Principal.ForcePrincipal
-
             $Identity = Resolve-Identity -Identity $PrincipalName
             $currentPrincipalAccess = $currentACL.Access.Where( {$_.IdentityReference -eq $Identity.Name})
             foreach ($Access in $currentPrincipalAccess)
@@ -139,9 +137,7 @@ Function Set-TargetResource
         }
 
         $actualAce = $currentAcl.Access
-
         $Results = Compare-RegistryRule -Expected $ACLRules -Actual $actualAce
-
         $Expected = $Results.Rules
         $AbsentToBeRemoved = $Results.Absent
         $ToBeRemoved = $Results.ToBeRemoved
@@ -153,12 +149,9 @@ Function Set-TargetResource
             $Principal = $AccessControlItem.Principal
             $Identity = Resolve-Identity -Identity $Principal
             $IdentityRef = New-Object System.Security.Principal.NTAccount($Identity.Name)
-
             $actualAce = $currentAcl.Access.Where( {$_.IdentityReference -eq $Identity.Name} )
-
             $ACLRules = ConvertTo-RegistryAccessRule -AccessControlList $AccessControlItem -IdentityRef $IdentityRef
             $Results = Compare-RegistryRule -Expected $ACLRules -Actual $actualAce
-
             $Expected += $Results.Rules
             $AbsentToBeRemoved += $Results.Absent
 
@@ -283,14 +276,11 @@ Function Test-TargetResource
             $Principal = $AccessControlItem.Principal
             $Identity = Resolve-Identity -Identity $Principal
             $IdentityRef = New-Object System.Security.Principal.NTAccount($Identity.Name)
-
             $ACLRules += ConvertTo-RegistryAccessRule -AccessControlList $AccessControlItem -IdentityRef $IdentityRef
         }
 
         $actualAce = $currentAcl.Access
-
         $Results = Compare-RegistryRule -Expected $ACLRules -Actual $actualAce
-
         $Expected = $Results.Rules
         $AbsentToBeRemoved = $Results.Absent
         $ToBeRemoved = $Results.ToBeRemoved
@@ -302,13 +292,9 @@ Function Test-TargetResource
             $Principal = $AccessControlItem.Principal
             $Identity = Resolve-Identity -Identity $Principal
             $IdentityRef = New-Object System.Security.Principal.NTAccount($Identity.Name)
-
             $ACLRules = ConvertTo-RegistryAccessRule -AccessControlList $AccessControlItem -IdentityRef $IdentityRef
-
             $actualAce = $currentAcl.Access.Where( {$_.IdentityReference -eq $Identity.Name} )
-
             $Results = Compare-RegistryRule -Expected $ACLRules -Actual $actualAce
-
             $Expected += $Results.Rules
             $AbsentToBeRemoved += $Results.Absent
 
@@ -316,7 +302,6 @@ Function Test-TargetResource
             {
                 $ToBeRemoved += $Results.ToBeRemoved
             }
-
         }
     }
 
@@ -389,9 +374,10 @@ Function Compare-RegistryRule
 
     $PresentRules = $Expected.Where( {$_.Ensure -eq 'Present'} ).Rules
     $AbsentRules = $Expected.Where( {$_.Ensure -eq 'Absent'} ).Rules
+
     foreach ($refrenceObject in $PresentRules)
     {
-        $match = $Actual.Where( {
+        $match = $Actual.Where({
                 $_.RegistryRights -eq $refrenceObject.RegistryRights -and
                 $_.InheritanceFlags -eq $refrenceObject.InheritanceFlags -and
                 $_.PropagationFlags -eq $refrenceObject.PropagationFlags -and
@@ -416,7 +402,7 @@ Function Compare-RegistryRule
 
     foreach ($refrenceObject in $Actual)
     {
-        $match = @($Expected.Rules).Where( {
+        $match = @($Expected.Rules).Where({
                 $_.RegistryRights -eq $refrenceObject.RegistryRights -and
                 $_.InheritanceFlags -eq $refrenceObject.InheritanceFlags -and
                 $_.PropagationFlags -eq $refrenceObject.PropagationFlags -and
@@ -433,7 +419,7 @@ Function Compare-RegistryRule
 
     foreach ($refrenceObject in $AbsentRules)
     {
-        $match = $Actual.Where( {
+        $match = $Actual.Where({
                 $_.RegistryRights -eq $refrenceObject.RegistryRights -and
                 $_.InheritanceFlags -eq $refrenceObject.InheritanceFlags -and
                 $_.PropagationFlags -eq $refrenceObject.PropagationFlags -and
@@ -515,17 +501,14 @@ Function Get-RegistryRuleInheritenceName
         "0-0"
         {
             return "This Key Only"
-
         }
         "1-0"
         {
             return "This Key and Subkeys"
-
         }
         "1-2"
         {
             return "Subkeys Only"
-
         }
     }
 
@@ -534,17 +517,17 @@ Function Get-RegistryRuleInheritenceName
 
 <#
     .SYNOPSIS
-    Takes a Rule object and converts the Principle Name to a SID
+        Takes a Rule object and converts the Principle Name to a SID
 
     .PARAMETER Rule
-    A single Registry Access Rule to be converted
+        A single Registry Access Rule to be converted
 
     .EXAMPLE
-    $sidRule = ConvertTo-SidIdentityRegistryAccessRule -Rule $Rule
+        $sidRule = ConvertTo-SidIdentityRegistryAccessRule -Rule $Rule
 
     .NOTES
-    This function was created to address translation issues with accounts such as
-    'APPLICATION PACKAGE AUTHORITY\ALL RESTRICTED APPLICATION PACKAGES'.
+        This function was created to address translation issues with accounts such as
+        'APPLICATION PACKAGE AUTHORITY\ALL RESTRICTED APPLICATION PACKAGES'.
 #>
 
 function ConvertTo-SidIdentityRegistryAccessRule
@@ -575,19 +558,19 @@ function ConvertTo-SidIdentityRegistryAccessRule
 
 <#
     .SYNOPSIS
-    Takes an ACL that contains the APPLICATION PACKAGE AUTHORITY\ALL APPLICATION PACKAGES principles with
-    an invalid RegistryRights enumeration and replaces them with their correct versions.
+        Takes an ACL that contains the APPLICATION PACKAGE AUTHORITY\ALL APPLICATION PACKAGES principles with
+        an invalid RegistryRights enumeration and replaces them with their correct versions.
 
     .PARAMETER AclObject
-    An ACL that contains APPLICATION PACKAGE AUTHORITY\ALL APPLICATION PACKAGES as the IdentityReference and
-    an invalid RegistryRights value, i.e.: -2147483648 (Generic Read) or 268435456 (Full Control)
+        An ACL that contains APPLICATION PACKAGE AUTHORITY\ALL APPLICATION PACKAGES as the IdentityReference and
+        an invalid RegistryRights value, i.e.: -2147483648 (Generic Read) or 268435456 (Full Control)
 
     .EXAMPLE
-    $modifiedAcl = Set-AllAppPackagesRegistryRightsAcl -AclObject $currentAcl
+        $modifiedAcl = Set-AllAppPackagesRegistryRightsAcl -AclObject $currentAcl
 
     .NOTES
-    This function was created to address translation / ACE removal issues with the
-    'APPLICATION PACKAGE AUTHORITY\ALL APPLICATION PACKAGES' principal.
+        This function was created to address translation / ACE removal issues with the
+        'APPLICATION PACKAGE AUTHORITY\ALL APPLICATION PACKAGES' principal.
 #>
 function Set-RegistryRightsAclAllAppPackages
 {
@@ -613,9 +596,9 @@ function Set-RegistryRightsAclAllAppPackages
 
     <#
         In order to remove the invalid RegistryRights ACEs, the RemoveAccessRuleAll method will be used, removing either Allow or Deny entries
-        The end result is AclObject will not have any 'ALL APPLICATION PACKAGES' ACEs, until they are readded in the second switch statement
-        The "ReadKey" Registry Right doesn't matter, however required to create the rule, when using the RemoveAccessRuleAll method,
-        just the SID/Account and AccessControlType (Allow/Deny)
+        for a given SID/Account. The result is AclObject will not have any 'ALL APPLICATION PACKAGES' Access Rules, until they are reapplied in the
+        second switch statement. The "ReadKey" RegistryRight is ignored when using the RemoveAccessRuleAll method, any RegistryRight would
+        work. The RemoveAccessRuleAll method evaluates the SID/Account and AccessControlType only, everything else in the AccessRule is ignored.
     #>
     switch ($allAppPackagesRegistryRule.AccessControlType | Select-Object -Unique)
     {
@@ -647,6 +630,7 @@ function Set-RegistryRightsAclAllAppPackages
             )
             $AclObject.AddAccessRule($newRegistryAccessRule)
         }
+
         {
             $_.IdentityReference -eq $data['IdentityReference'] -and $_.RegistryRights -eq $data['RegistryRights']['ReadKey']
         }
@@ -663,6 +647,7 @@ function Set-RegistryRightsAclAllAppPackages
     }
 
     $validAccessRules = $allAppPackagesRegistryRule.Where( {$_.IdentityReference -eq $data['IdentityReference'] -and $data['RegistryRightEnums'] -contains $_.RegistryRights} )
+
     foreach ($validAccessRule in $validAccessRules)
     {
         $convertedValidSidRule = ConvertTo-SidIdentityRegistryAccessRule -Rule $validAccessRule

--- a/DscResources/RegistryAccessEntry/RegistryAccessEntry.psm1
+++ b/DscResources/RegistryAccessEntry/RegistryAccessEntry.psm1
@@ -180,14 +180,14 @@ Function Set-TargetResource
 
     foreach ($Rule in $AbsentToBeRemoved.Rule)
     {
-        $currentAcl.RemoveAccessRule($Rule)
+        $currentAcl.RemoveAccessRuleSpecific($Rule)
     }
 
     foreach ($Rule in $ToBeRemoved.Rule)
     {
         try
         {
-            $currentAcl.RemoveAccessRule($Rule)
+            $currentAcl.RemoveAccessRuleSpecific($Rule)
         }
         catch
         {
@@ -195,7 +195,7 @@ Function Set-TargetResource
             {
                 #If failure due to Identity translation issue then create the same rule with the identity as a sid to remove account
                 $SIDRule = ConvertTo-SidIdentityRegistryAccessRule -Rule $Rule
-                $currentAcl.RemoveAccessRule($SIDRule)
+                $currentAcl.RemoveAccessRuleSpecific($SIDRule)
             }
             catch
             {

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Please check out common DSC Resources [contributing guidelines](
 
     * **[String] ObjectType:** Specifies the object type name that identifies the type of child object that can inherit this access rule.
 
-  * [String] ForcePrincipal: Indicates whether the rights for this principal should be forced.  Will remove any rights not explicitly defined in the configuration for the principal.
+  * **[String] ForcePrincipal:** Indicates whether the rights for this principal should be forced.  Will remove any rights not explicitly defined in the configuration for the principal.
 
 #### ActiveDirectoryAccessRule Examples
 
@@ -78,9 +78,9 @@ Please check out common DSC Resources [contributing guidelines](
 
     * **[String] InheritedObjectType:** Specifies the object type name that identifies the type of child object that can inherit this access rule.
 
-  * [String] ForcePrincipal: Indicates whether the rights for this principal should be forced.  Will remove any rights not explicitly defined in the configuration for the principal.
+  * **[String] ForcePrincipal:** Indicates whether the rights for this principal should be forced.  Will remove any rights not explicitly defined in the configuration for the principal.
 
-* [Boolean] Force: Indicates whether the rights defined should be enforced.  Will remove any rights not explicitly defined in the configuration for the path.
+* **[Boolean] Force:** Indicates whether the rights defined should be enforced.  Will remove any rights not explicitly defined in the configuration for the path.
 
 #### ActiveDirectoryAuditRule Examples
 
@@ -105,9 +105,9 @@ Please check out common DSC Resources [contributing guidelines](
 
     * **[String] Inheritance:** Indicates the inheritance type of the permission entry.
 
-  * [String] ForcePrincipal: Indicates whether the rights for this principal should be forced.  Will remove any rights not explicitly defined in the configuration for the principal.
+  * **[String] ForcePrincipal:** Indicates whether the rights for this principal should be forced.  Will remove any rights not explicitly defined in the configuration for the principal.
 
-* [Boolean] Force: Indicates whether the rights defined should be enforced.  Will remove any rights not explicitly defined in the configuration for the path.
+* **[Boolean] Force:** Indicates whether the rights defined should be enforced.  Will remove any rights not explicitly defined in the configuration for the path.
 
 #### NtfsAccessEntry Examples
 
@@ -132,9 +132,9 @@ Please check out common DSC Resources [contributing guidelines](
 
     * **[String] Inheritance:** Indicates the inheritance type of the permission entry. _{ This Key Only | This Key and Subkeys | SubKeys Only }_
 
-  * [String] ForcePrincipal: Indicates whether the rights for this principal should be forced.  Will remove any rights not explicitly defined in the configuration for the principal.
+  * **[String] ForcePrincipal:** Indicates whether the rights for this principal should be forced.  Will remove any rights not explicitly defined in the configuration for the principal.
 
-* [Boolean] Force: Indicates whether the rights defined should be enforced.  Will remove any rights not explicitly defined in the configuration for the path.
+* **[Boolean] Force:** Indicates whether the rights defined should be enforced.  Will remove any rights not explicitly defined in the configuration for the path.
 
 #### RegistryAccessEntry Examples
 

--- a/Tests/TestHelper.psm1
+++ b/Tests/TestHelper.psm1
@@ -112,22 +112,22 @@ function New-AccessControlList
 <#
     .SYNOPSIS
     Creates an Access Control List Ciminstance
-    
+
     .PARAMETER Principal
-    Name of the principal which access rights are being managed 
-    
+    Name of the principal which access rights are being managed
+
     .PARAMETER ForcePrincipal
         Used to force the desired access rule
-    
+
     .PARAMETER AccessControlType
     States if the principal should be will be allowed or denied access
-    
+
     .PARAMETER FileSystemRights
     What rights the principal is being given over an object
-    
+
     .PARAMETER Inheritance
     The inheritance properties of the object being managed
-    
+
     .PARAMETER Ensure
     Either Present or Absent
 #>
@@ -148,7 +148,7 @@ function New-AccessControlList
         [Parameter(Mandatory = $false)]
         [ValidateSet("ListDirectory", "ReadData", "WriteData", "CreateFiles", "CreateDirectories", "AppendData", "ReadExtendedAttributes", "WriteExtendedAttributes", "Traverse", "ExecuteFile", "DeleteSubdirectoriesAndFiles", "ReadAttributes", "WriteAttributes", "Write", "Delete", "ReadPermissions", "Read", "ReadAndExecute", "Modify", "ChangePermissions", "TakeOwnership", "Synchronize", "FullControl")]
         $FileSystemRights,
-        
+
         [Parameter(Mandatory = $false)]
         [ValidateSet("This Folder Only","This Folder Subfolders and Files","This Folder and Subfolders","This Folder and Files","Subfolders and Files Only","Subfolders Only","Files Only")]
         [String]
@@ -192,22 +192,22 @@ function New-RegistryAccessControlList
 <#
     .SYNOPSIS
         Creates an Access Control List Ciminstance for registry rules
-    
+
     .PARAMETER Principal
-        Name of the principal which access rights are being managed 
-    
+        Name of the principal which access rights are being managed
+
     .PARAMETER ForcePrincipal
         Used to force the desired access rule
-    
+
     .PARAMETER AccessControlType
         States if the principal should be will be allowed or denied access
-    
+
     .PARAMETER RegistryRights
         Rights to be given to a principal over an object
-    
+
     .PARAMETER Inheritance
         The inheritance properties of the object being managed
-    
+
     .PARAMETER Ensure
         Either Present or Absent
 #>
@@ -228,7 +228,7 @@ function New-RegistryAccessControlList
         [Parameter(Mandatory = $false)]
         [ValidateSet("ChangePermissions", "CreateLink", "CreateSubkey", "Delete", "EnumerateSubKeys", "ExecuteKey", "FullControl", "Notify", "QueryValues", "ReadKey", "ReadPermissions", "SetValue", "TakeOwnership", "WriteKey")]
         $RegistryRights,
-        
+
         [Parameter(Mandatory = $false)]
         [ValidateSet("Key", "KeySubkeys", "Subkeys")]
         [String]
@@ -354,7 +354,7 @@ function New-AuditAccessControlList
     Creates an Access Control List Ciminstance
 
     .PARAMETER Principal
-    Name of the principal which access rights are being managed 
+    Name of the principal which access rights are being managed
 
     .PARAMETER ForcePrincipal
         Used to force the desired access rule
@@ -438,7 +438,7 @@ function New-AuditAccessControlList
     Creates an Access Control List Ciminstance
 
     .PARAMETER Principal
-    Name of the principal which access rights are being managed 
+    Name of the principal which access rights are being managed
 
     .PARAMETER ForcePrincipal
         Used to force the desired access rule
@@ -529,4 +529,52 @@ function New-ActiveDirectoryAccessControlList
                         }
     }
     Return $CimAccessControlList
+}
+
+<#
+    .SYNOPSIS
+        Creates a new item and returns the associated Acl Object
+
+    .PARAMETER Path
+        Specifies the path of the location of the new item. Wildcard characters are permitted.
+
+        You can specify the name of the new item in Name , or include it in Path .
+
+    .PARAMETER Force
+        Forces this function to create an item that writes over an existing read-only item. Implementation varies from
+        provider to provider. For more information, see about_Providers. Even using the Force parameter, the function cannot
+        override security restrictions.
+
+    .PARAMETER DisableInheritance
+        Disables inheritance from the newly created item.
+#>
+function New-TempAclItem
+{
+    [CmdletBinding()]
+    Param
+    (
+        [Parameter(Mandatory = $true)]
+        [String]
+        $Path,
+
+        [Parameter()]
+        [Switch]
+        $Force,
+
+        [Parameter()]
+        [Switch]
+        $DisableInheritance
+    )
+
+    $newTempAclItem = New-Item -Path $Path -Force:$Force
+    $newTempAcl = $newTempAclItem.GetAccessControl()
+
+    if ($PSBoundParameters.ContainsKey('DisableInheritance'))
+    {
+        $newTempAcl.SetAccessRuleProtection($true, $true)
+        Set-Acl -Path $Path -AclObject $newTempAcl
+        $newTempAcl = $newTempAclItem.GetAccessControl()
+    }
+
+    return $newTempAcl
 }

--- a/Tests/TestHelper.psm1
+++ b/Tests/TestHelper.psm1
@@ -551,6 +551,7 @@ function New-ActiveDirectoryAccessControlList
 function New-TempAclItem
 {
     [CmdletBinding()]
+    [OutputType([System.Object])]
     Param
     (
         [Parameter(Mandatory = $true)]

--- a/Tests/Unit/RegistryAccessEntry.Tests.ps1
+++ b/Tests/Unit/RegistryAccessEntry.Tests.ps1
@@ -1422,8 +1422,8 @@ Describe "$DSCResourceName\Set-RegistryRightsAclAllAppPackages" {
 
         It "Should have invalid RegistryAccess Rules for 'ALL APPLICATION PACKAGES'" {
             $invalidAppAccessRule = $tempRegKeyAcl.Access.Where( {
-                    $_.IdentityReference -eq $allAppPackage -and $_.RegistryRights -eq -2147483648
-                })
+                $_.IdentityReference -eq $allAppPackage -and $_.RegistryRights -eq -2147483648
+            })
             $invalidAppAccessRule.RegistryRights    | Should Be -2147483648
             $invalidAppAccessRule.IdentityReference | Should Be $allAppPackage
         }

--- a/Tests/Unit/RegistryAccessEntry.Tests.ps1
+++ b/Tests/Unit/RegistryAccessEntry.Tests.ps1
@@ -11,7 +11,7 @@ Import-Module "$($PSScriptRoot)\..\TestHelper.psm1" -Force
 
 Describe "$DSCResourceName\Get-TargetResource" {
     Context "Permissions should exist" {
-        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights FullControl -Inheritance 'Key' -Ensure Absent 
+        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights FullControl -Inheritance 'Key' -Ensure Absent
         $pathName = "HKCU:\TestKey"
         $ContextParams = @{
             Path = $pathName
@@ -27,7 +27,7 @@ Describe "$DSCResourceName\Get-TargetResource" {
                 'None',
                 'Allow'
             )
-        
+
             New-Object -TypeName System.Security.AccessControl.RegistryAccessRule `
             -ArgumentList @(
                 $TempAcl.Principal,
@@ -35,28 +35,28 @@ Describe "$DSCResourceName\Get-TargetResource" {
                 'None',
                 'None',
                 'Allow'
-            )            
+            )
         )
 
-        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules 
+        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules
         $GetResult = & "$($DSCResourceName)\Get-TargetResource" @ContextParams
 
         It 'Should return Ensure set as empty' {
             $GetResult.AccessControl.AccessControlEntry.Ensure | Should Be $null
         }
-                    
+
         It "Should return $false from GetReturn.Force" {
             $GetResult.Force | Should Be $false
         }
-        
+
         It 'Should return Path' {
             $GetResult.Path | Should Be $ContextParams.Path
         }
-        
+
         It 'Should return Principal' {
             $GetResult.Principal | Should Be $ContextParams.Principal
         }
-        
+
         It 'Should return AccessControlEntries' {
             $GetResult.AccessControlList.AccessControlEntry.Count | Should Be $TempAccessRules.Count
         }
@@ -69,13 +69,13 @@ Describe "$DSCResourceName\Get-TargetResource" {
 
     Context 'No permissions exist' {
         $pathName = "HKCU:\TestKey"
-        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights FullControl -Inheritance 'Key' -Ensure Absent 
+        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights FullControl -Inheritance 'Key' -Ensure Absent
         $ContextParams = @{
             Path = $pathName
             AccessControlList = $TempAcl
         }
 
-        Set-NewTempRegKeyAcl -Path $PathName 
+        Set-NewTempRegKeyAcl -Path $PathName
 
         $GetResult = Get-TargetResource @ContextParams
 
@@ -105,14 +105,14 @@ Describe "$DSCResourceName\Get-TargetResource" {
 Describe "$DSCResourceName\Test-TargetResource behavior with Ensure set to Absent" {
     Context 'AccessControlInformation is specified, no permissions exist' {
         $pathName = "HKCU:\TestKey"
-        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights FullControl -Inheritance 'Key' -Ensure Absent 
+        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights FullControl -Inheritance 'Key' -Ensure Absent
         $ContextParams = @{
             Path = $pathName
             AccessControlList = $TempAcl
         }
 
-        Set-NewTempRegKeyAcl -Path $PathName 
-        
+        Set-NewTempRegKeyAcl -Path $PathName
+
         It 'Should return True' {
             Test-TargetResource @ContextParams | Should Be $true
         }
@@ -120,7 +120,7 @@ Describe "$DSCResourceName\Test-TargetResource behavior with Ensure set to Absen
 
     Context 'AccessControlInformation is specified, no matching permissions exist' {
         $pathName = "HKCU:\TestKey"
-        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights FullControl -Inheritance 'Key' -Ensure Absent 
+        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights FullControl -Inheritance 'Key' -Ensure Absent
         $ContextParams = @{
             Path = $pathName
             AccessControlList = $TempAcl
@@ -154,8 +154,8 @@ Describe "$DSCResourceName\Test-TargetResource behavior with Ensure set to Absen
                 )
         )
 
-        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules 
-        
+        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules
+
         It 'Should return True' {
             Test-TargetResource @ContextParams | Should Be $true
         }
@@ -168,7 +168,7 @@ Describe "$DSCResourceName\Test-TargetResource behavior with Ensure set to Absen
 
     Context 'AccessControlInformation is specified, matching permissions exist' {
         $pathName = "HKCU:\TestKey"
-        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights FullControl -Inheritance 'Key' -Ensure Absent 
+        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights FullControl -Inheritance 'Key' -Ensure Absent
         $ContextParams = @{
             Path = $pathName
             AccessControlList = $TempAcl
@@ -184,8 +184,8 @@ Describe "$DSCResourceName\Test-TargetResource behavior with Ensure set to Absen
                 )
         )
 
-        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules 
-        
+        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules
+
         It 'Should return False' {
             Test-TargetResource @ContextParams | Should Be $false
         }
@@ -198,12 +198,12 @@ Describe "$DSCResourceName\Test-TargetResource behavior with Ensure set to Absen
 
     Context 'AccessControlInformation is not specified' {
         $pathName = "HKCU:\TestKey"
-        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -Inheritance 'Key' -Ensure Absent 
+        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -Inheritance 'Key' -Ensure Absent
         $ContextParams = @{
             Path = $pathName
             AccessControlList = $TempAcl
         }
-    
+
         $TempAccessRules = @(
             New-Object -TypeName System.Security.AccessControl.RegistryAccessRule `
                 -ArgumentList @(
@@ -213,7 +213,7 @@ Describe "$DSCResourceName\Test-TargetResource behavior with Ensure set to Absen
                     'None',
                     'Allow'
                 )
-    
+
             New-Object -TypeName System.Security.AccessControl.RegistryAccessRule `
                 -ArgumentList @(
                     $TempAcl.Principal,
@@ -222,7 +222,7 @@ Describe "$DSCResourceName\Test-TargetResource behavior with Ensure set to Absen
                     'None',
                     'Allow'
                 )
-    
+
             New-Object -TypeName System.Security.AccessControl.RegistryAccessRule `
                 -ArgumentList @(
                     $TempAcl.Principal,
@@ -232,11 +232,11 @@ Describe "$DSCResourceName\Test-TargetResource behavior with Ensure set to Absen
                     'Allow'
                 )
         )
-    
-        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules 
-        
+
+        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules
+
         It 'Should Throw When Test-TargetResource is run' {
-            
+
             { Test-TargetResource @ContextParams }| Should Throw
         }
 
@@ -250,14 +250,14 @@ Describe "$DSCResourceName\Test-TargetResource behavior with Ensure set to Absen
 Describe "$DSCResourceName\Test-TargetResource behavior with Ensure set to Present" {
     Context 'AccessControlInformation is specified, no permissions exist' {
         $pathName = "HKCU:\TestKey"
-        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights FullControl -Inheritance 'KeySubkeys' -Ensure Present 
+        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights FullControl -Inheritance 'KeySubkeys' -Ensure Present
         $ContextParams = @{
             Path = $pathName
             AccessControlList = $TempAcl
         }
 
         Set-NewTempRegKeyAcl -Path $PathName
-        
+
         It 'Should return False' {
             Test-TargetResource @ContextParams | Should Be $false
         }
@@ -270,7 +270,7 @@ Describe "$DSCResourceName\Test-TargetResource behavior with Ensure set to Prese
 
     Context 'AccessControlInformation is specified, desired permissions exist, other permissions exist and ForcePrincipal is set to true' {
         $pathName = "HKCU:\TestKey"
-        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $True -AccessControlType Allow -RegistryRights @('CreateLink', 'CreateSubkey') -Inheritance 'Key' -Ensure Present 
+        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $True -AccessControlType Allow -RegistryRights @('CreateLink', 'CreateSubkey') -Inheritance 'Key' -Ensure Present
         $ContextParams = @{
             Path = $pathName
             AccessControlList = $TempAcl
@@ -304,8 +304,8 @@ Describe "$DSCResourceName\Test-TargetResource behavior with Ensure set to Prese
                 )
         )
 
-        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules 
-        
+        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules
+
         It 'Should return False' {
             Test-TargetResource @ContextParams | Should Be $false
         }
@@ -318,7 +318,7 @@ Describe "$DSCResourceName\Test-TargetResource behavior with Ensure set to Prese
 
     Context 'AccessControlInformation is specified, correct permissions exist and ForcePrincipal is set to true' {
         $pathName = "HKCU:\TestKey"
-        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $True -AccessControlType Allow -RegistryRights FullControl -Inheritance 'Subkeys' -Ensure Present 
+        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $True -AccessControlType Allow -RegistryRights FullControl -Inheritance 'Subkeys' -Ensure Present
         $ContextParams = @{
             Path = $pathName
             AccessControlList = $TempAcl
@@ -334,8 +334,8 @@ Describe "$DSCResourceName\Test-TargetResource behavior with Ensure set to Prese
                )
         )
 
-        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules 
-        
+        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules
+
         It 'Should return True' {
             Test-TargetResource @ContextParams | Should Be $true
         }
@@ -348,7 +348,7 @@ Describe "$DSCResourceName\Test-TargetResource behavior with Ensure set to Prese
 
     Context 'AccessControlInformation is specified, desired permissions exist, other permissions exist and ForcePrincipal is set to false' {
         $pathName = "HKCU:\TestKey"
-        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights @('CreateLink', 'CreateSubkey') -Inheritance 'Key' -Ensure Present 
+        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights @('CreateLink', 'CreateSubkey') -Inheritance 'Key' -Ensure Present
         $ContextParams = @{
             Path = $pathName
             AccessControlList = $TempAcl
@@ -373,8 +373,8 @@ Describe "$DSCResourceName\Test-TargetResource behavior with Ensure set to Prese
                 )
         )
 
-        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules 
-        
+        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules
+
         It 'Should return True' {
             Test-TargetResource @ContextParams | Should Be $true
         }
@@ -387,12 +387,12 @@ Describe "$DSCResourceName\Test-TargetResource behavior with Ensure set to Prese
 
     Context 'AccessControlInformation is not specified' {
         $pathName = "HKCU:\TestKey"
-        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -Inheritance 'Key' -Ensure Present 
+        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -Inheritance 'Key' -Ensure Present
         $ContextParams = @{
             Path = $pathName
             AccessControlList = $TempAcl
         }
-    
+
         $TempAccessRules = @(
             New-Object -TypeName System.Security.AccessControl.RegistryAccessRule `
                 -ArgumentList @(
@@ -421,11 +421,11 @@ Describe "$DSCResourceName\Test-TargetResource behavior with Ensure set to Prese
                     'Allow'
                 )
         )
-    
-        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules 
-        
+
+        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules
+
         It 'Should Throw When Test-TargetResource is run' {
-            
+
             { Test-TargetResource @ContextParams }| Should Throw
         }
 
@@ -439,12 +439,12 @@ Describe "$DSCResourceName\Test-TargetResource behavior with Ensure set to Prese
 Describe "$DSCResourceName\Set-TargetResource behavior with Ensure set to Absent" {
     Context 'AccessControlInformation is not specified' {
         $pathName = "HKCU:\TestKey"
-        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -Inheritance 'Key' -Ensure Absent 
+        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -Inheritance 'Key' -Ensure Absent
         $ContextParams = @{
             Path = $pathName
             AccessControlList = $TempAcl
         }
-        
+
         $TempAccessRules = @(
             New-Object -TypeName System.Security.AccessControl.RegistryAccessRule `
                 -ArgumentList @(
@@ -473,11 +473,11 @@ Describe "$DSCResourceName\Set-TargetResource behavior with Ensure set to Absent
                     'Allow'
                 )
         )
-        
-        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules 
-        
+
+        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules
+
         It 'Should Throw When Set-TargetResource is run' {
-            
+
             { Set-TargetResource @ContextParams }| Should Throw
         }
 
@@ -489,7 +489,7 @@ Describe "$DSCResourceName\Set-TargetResource behavior with Ensure set to Absent
 
     Context 'AccessControlInformation is specified, matching permissions exist, ForcePrincipal is set to false' {
         $pathName = "HKCU:\TestKey"
-        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights EnumerateSubKeys -Inheritance 'Key' -Ensure Absent 
+        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights EnumerateSubKeys -Inheritance 'Key' -Ensure Absent
         $ContextParams = @{
             Path = $pathName
             AccessControlList = $TempAcl
@@ -524,13 +524,13 @@ Describe "$DSCResourceName\Set-TargetResource behavior with Ensure set to Absent
                 )
         )
 
-        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules 
-        
+        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules
+
         It 'Should remove matching permissions' {
 
             (Get-Acl -Path $ContextParams.Path).Access.Where(
                 {$_.IsInherited -eq $false -and $_.IdentityReference -eq $TempAcl.Principal}
-            ).Count | 
+            ).Count |
             Should Be $TempAccessRules.Count
 
             Test-TargetResource @ContextParams | Should Be $false
@@ -553,7 +553,7 @@ Describe "$DSCResourceName\Set-TargetResource behavior with Ensure set to Absent
 
     Context 'AccessControlInformation is specified, no matching permissions exist, ForcePrincipal is set to false' {
         $pathName = "HKCU:\TestKey"
-        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights FullControl -Inheritance 'KeySubKeys' -Ensure Absent 
+        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights FullControl -Inheritance 'KeySubKeys' -Ensure Absent
         $ContextParams = @{
             Path = $pathName
             AccessControlList = $TempAcl
@@ -588,13 +588,13 @@ Describe "$DSCResourceName\Set-TargetResource behavior with Ensure set to Absent
                 )
         )
 
-        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules 
-        
+        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules
+
         It 'Should not change any of the permissions' {
 
             (Get-Acl -Path $ContextParams.Path).Access.Where(
                 {$_.IsInherited -eq $false -and $_.IdentityReference -eq $TempAcl.Principal}
-            ).Count | 
+            ).Count |
             Should Be $TempAccessRules.Count
 
             Test-TargetResource @ContextParams | Should Be $true
@@ -617,7 +617,7 @@ Describe "$DSCResourceName\Set-TargetResource behavior with Ensure set to Absent
 
     Context 'AccessControlInformation is specified, matching permissions exist, ForcePrincipal is set to true' {
         $pathName = "HKCU:\TestKey"
-        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $true -AccessControlType Allow -RegistryRights FullControl -Inheritance 'Key' -Ensure Absent 
+        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $true -AccessControlType Allow -RegistryRights FullControl -Inheritance 'Key' -Ensure Absent
         $ContextParams = @{
             Path = $pathName
             AccessControlList = $TempAcl
@@ -652,13 +652,13 @@ Describe "$DSCResourceName\Set-TargetResource behavior with Ensure set to Absent
                 )
         )
 
-        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules 
-        
+        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules
+
         It 'Should Remove Principal from Access Control List' {
 
             (Get-Acl -Path $ContextParams.Path).Access.Where(
                 {$_.IsInherited -eq $false -and $_.IdentityReference -eq $TempAcl.Principal}
-            ).Count | 
+            ).Count |
             Should Be $TempAccessRules.Count
 
             Test-TargetResource @ContextParams | Should Be $false
@@ -681,7 +681,7 @@ Describe "$DSCResourceName\Set-TargetResource behavior with Ensure set to Absent
 
     Context 'AccessControlInformation is specified, no matching permissions exist, ForcePrincipal is set to true' {
         $pathName = "HKCU:\TestKey"
-        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $true -AccessControlType Allow -RegistryRights FullControl -Inheritance 'Key' -Ensure Absent 
+        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $true -AccessControlType Allow -RegistryRights FullControl -Inheritance 'Key' -Ensure Absent
         $ContextParams = @{
             Path = $pathName
             AccessControlList = $TempAcl
@@ -716,13 +716,13 @@ Describe "$DSCResourceName\Set-TargetResource behavior with Ensure set to Absent
                 )
         )
 
-        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules 
-        
+        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules
+
         It 'Should Remove Principal from Access Control List' {
 
             (Get-Acl -Path $ContextParams.Path).Access.Where(
                 {$_.IsInherited -eq $false -and $_.IdentityReference -eq $TempAcl.Principal}
-            ).Count | 
+            ).Count |
             Should Be $TempAccessRules.Count
 
             Test-TargetResource @ContextParams | Should Be $false
@@ -747,12 +747,12 @@ Describe "$DSCResourceName\Set-TargetResource behavior with Ensure set to Absent
 Describe "$DSCResourceName\Set-TargetResource behavior with Ensure set to Present" {
     Context 'AccessControlInformation is not specified' {
         $pathName = "HKCU:\TestKey"
-        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -Inheritance 'Key' -Ensure Present 
+        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -Inheritance 'Key' -Ensure Present
         $ContextParams = @{
             Path = $pathName
             AccessControlList = $TempAcl
         }
-    
+
         $TempAccessRules = @(
             New-Object -TypeName System.Security.AccessControl.RegistryAccessRule `
                 -ArgumentList @(
@@ -781,11 +781,11 @@ Describe "$DSCResourceName\Set-TargetResource behavior with Ensure set to Presen
                     'Allow'
                 )
         )
-    
-        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules 
-        
+
+        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules
+
         It 'Should Throw When Set-TargetResource is run' {
-            
+
             { Set-TargetResource @ContextParams }| Should Throw
         }
 
@@ -797,14 +797,14 @@ Describe "$DSCResourceName\Set-TargetResource behavior with Ensure set to Presen
 
     Context 'AccessControlInformation is specified, no permissions exist' {
         $pathName = "HKCU:\TestKey"
-        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights FullControl -Inheritance 'Key' -Ensure Present 
+        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights FullControl -Inheritance 'Key' -Ensure Present
         $ContextParams = @{
             Path = $pathName
             AccessControlList = $TempAcl
         }
 
         Set-NewTempRegKeyAcl -Path $PathName
-        
+
         It 'Should add the desired permissions' {
 
             (Get-Acl -Path $ContextParams.Path).Access.Where(
@@ -832,7 +832,7 @@ Describe "$DSCResourceName\Set-TargetResource behavior with Ensure set to Presen
 
     Context 'AccessControlInformation is specified, desired permissions exist, other permissions exist, ForcePrincipal is set to true' {
         $pathName = "HKCU:\TestKey"
-        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $True -AccessControlType Allow -RegistryRights FullControl -Inheritance 'Subkeys' -Ensure Present 
+        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $True -AccessControlType Allow -RegistryRights FullControl -Inheritance 'Subkeys' -Ensure Present
         $ContextParams = @{
             Path = $pathName
             AccessControlList = $TempAcl
@@ -858,8 +858,8 @@ Describe "$DSCResourceName\Set-TargetResource behavior with Ensure set to Presen
                 )
         )
 
-        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules 
-        
+        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules
+
         It 'Should remove other permissions' {
 
             (Get-Acl -Path $ContextParams.Path).Access.Where(
@@ -887,7 +887,7 @@ Describe "$DSCResourceName\Set-TargetResource behavior with Ensure set to Presen
 
     Context 'AccessControlInformation is specified, desired permissions exist, other permissions exist, ForcePrincipal is set to false' {
         $pathName = "HKCU:\TestKey"
-        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights CreateSubkey -Inheritance 'Key' -Ensure Present 
+        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights CreateSubkey -Inheritance 'Key' -Ensure Present
         $ContextParams = @{
             Path = $pathName
             AccessControlList = $TempAcl
@@ -921,8 +921,8 @@ Describe "$DSCResourceName\Set-TargetResource behavior with Ensure set to Presen
                 )
         )
 
-        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules 
-        
+        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules
+
         It 'Should Keep all the permissions' {
 
             (Get-Acl -Path $ContextParams.Path).Access.Where(
@@ -950,7 +950,7 @@ Describe "$DSCResourceName\Set-TargetResource behavior with Ensure set to Presen
 
     Context 'AccessControlInformation is specified, desired permissions do not exist, other permissions exist, ForcePrincipal is set to true' {
         $pathName = "HKCU:\TestKey"
-        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $true -AccessControlType Allow -RegistryRights FullControl -Inheritance 'Key' -Ensure Present 
+        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $true -AccessControlType Allow -RegistryRights FullControl -Inheritance 'Key' -Ensure Present
         $ContextParams = @{
             Path = $pathName
             AccessControlList = $TempAcl
@@ -976,8 +976,8 @@ Describe "$DSCResourceName\Set-TargetResource behavior with Ensure set to Presen
                 )
         )
 
-        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules 
-        
+        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules
+
         It 'Should remove other permissions and add Desired Access Control Entry' {
 
             (Get-Acl -Path $ContextParams.Path).Access.Where(
@@ -1005,7 +1005,7 @@ Describe "$DSCResourceName\Set-TargetResource behavior with Ensure set to Presen
 
     Context 'AccessControlInformation is specified, desired permissions do not exist, other permissions exist, ForcePrincipal is set to false' {
         $pathName = "HKCU:\TestKey"
-        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights Delete -Inheritance 'KeySubKeys' -Ensure Present 
+        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights Delete -Inheritance 'KeySubKeys' -Ensure Present
         $ContextParams = @{
             Path = $pathName
             AccessControlList = $TempAcl
@@ -1031,8 +1031,8 @@ Describe "$DSCResourceName\Set-TargetResource behavior with Ensure set to Presen
                 )
         )
 
-        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules 
-        
+        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules
+
         It 'Should add Desired Access Control Entry and leave existing Entries' {
 
             (Get-Acl -Path $ContextParams.Path).Access.Where(
@@ -1095,25 +1095,25 @@ Describe "$DSCResourceName\Get-RegistryRuleInheritenceName" {
     Context "Inheritance and Propagation Flags" {
         It "Should return Key" {
             $InheritanceName = Get-RegistryRuleInheritenceName -InheritanceFlag 0 -PropagationFlag 0
-    
+
             $InheritanceName | Should be "This Key Only"
         }
-    
+
         It "Should return KeySubkeys" {
             $InheritanceName = Get-RegistryRuleInheritenceName -InheritanceFlag 1 -PropagationFlag 0
-    
+
             $InheritanceName | Should be "This Key and Subkeys"
         }
-    
+
         It "Should return Subkeys" {
             $InheritanceName = Get-RegistryRuleInheritenceName -InheritanceFlag 1 -PropagationFlag 2
-    
+
             $InheritanceName | Should be "Subkeys Only"
         }
-    
+
         It "Should return none if abnormal Inheritance and Propagation Flags are passed" {
             $InheritanceName = Get-RegistryRuleInheritenceName -InheritanceFlag 4 -PropagationFlag 4
-    
+
             $InheritanceName | Should be "none"
         }
     }
@@ -1122,16 +1122,16 @@ Describe "$DSCResourceName\Get-RegistryRuleInheritenceName" {
 Describe "$DSCResourceName\ConvertTo-RegistryAccessRule" {
     Context "Should convert to a valid Registry Key Access Rule" {
         It "Should return a FilseSystemAccessRule Object" {
-            $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights FullControl -Inheritance 'Key' -Ensure Absent 
+            $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights FullControl -Inheritance 'Key' -Ensure Absent
             $FileSystemAccessRule = ConvertTo-RegistryAccessRule -AccessControlList $TempAcl -IdentityRef $TempAcl.Principal
-    
+
            $FileSystemAccessRule.Rules | Should BeOfType System.Security.AccessControl.RegistryAccessRule
         }
-    
+
         It "Should return expected values" {
             $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights FullControl -Inheritance 'Key' -Ensure Present
             $FileSystemAccessRule = ConvertTo-RegistryAccessRule -AccessControlList $TempAcl -IdentityRef $TempAcl.Principal
-    
+
             $FileSystemAccessRule.Rules.RegistryRights | Should Be "FullControl"
             $FileSystemAccessRule.Rules.AccessControlType | Should Be "Allow"
             $FileSystemAccessRule.Rules.IdentityReference | Should Be "Everyone"
@@ -1145,7 +1145,7 @@ Describe "$DSCResourceName\ConvertTo-RegistryAccessRule" {
 Describe "$DSCResourceName\Compare-RegistryRule" {
     Context "Compare-RegistryRule with Ensure set to Absent with no matching rules" {
         $pathName = "HKCU:\TestKey"
-        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights EnumerateSubKeys -Inheritance 'Key' -Ensure Absent 
+        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights EnumerateSubKeys -Inheritance 'Key' -Ensure Absent
 
         $TempAccessRules = @(
             New-Object -TypeName System.Security.AccessControl.RegistryAccessRule `
@@ -1167,13 +1167,13 @@ Describe "$DSCResourceName\Compare-RegistryRule" {
                 )
         )
 
-        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules 
-        
+        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules
+
         $Principal = $TempAcl.Principal
         $Identity = Resolve-Identity -Identity $Principal
         $IdentityRef = [System.Security.Principal.NTAccount]::new($Identity.Name)
         $ACLRules += ConvertTo-RegistryAccessRule -AccessControlList $TempAcl -IdentityRef $IdentityRef
-        
+
         $currentACL = Get-Acl -Path $pathName
         $actualAce = $currentAcl.Access.Where({$_.IdentityReference -eq $Identity.Name})
 
@@ -1192,7 +1192,7 @@ Describe "$DSCResourceName\Compare-RegistryRule" {
 
     Context "Compare-NtfsRule with Ensure set to Absent with matching rules" {
         $pathName = "HKCU:\TestKey"
-        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights Delete -Inheritance 'Key' -Ensure Absent 
+        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights Delete -Inheritance 'Key' -Ensure Absent
 
         $TempAccessRules = @(
             New-Object -TypeName System.Security.AccessControl.RegistryAccessRule `
@@ -1214,20 +1214,20 @@ Describe "$DSCResourceName\Compare-RegistryRule" {
                 )
         )
 
-        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules 
-        
+        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules
+
         $Principal = $TempAcl.Principal
         $Identity = Resolve-Identity -Identity $Principal
         $IdentityRef = [System.Security.Principal.NTAccount]::new($Identity.Name)
         $ACLRules += ConvertTo-RegistryAccessRule -AccessControlList $TempAcl -IdentityRef $IdentityRef
-        
+
         $currentACL = Get-Acl -Path $pathName
         $actualAce = $currentAcl.Access.Where({$_.IdentityReference -eq $Identity.Name})
 
         It "Should have matching rule to be removed" {
             $testComparison = Compare-RegistryRule -Expected $ACLRules -Actual $actualAce
 
-            $testComparison.ToBeRemoved.Rule.Count | Should be ($actualAce.Count - $TempAcl.AccessControlEntry.Count) 
+            $testComparison.ToBeRemoved.Rule.Count | Should be ($actualAce.Count - $TempAcl.AccessControlEntry.Count)
             $testComparison.Absent.Count | Should Be $TempAcl.AccessControlEntry.Count
         }
 
@@ -1239,7 +1239,7 @@ Describe "$DSCResourceName\Compare-RegistryRule" {
 
     Context "Compare-NtfsRule with Ensure set to Present with no matching rules" {
         $pathName = "HKCU:\TestKey"
-        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights CreateSubkey -Inheritance 'KeySubKeys' -Ensure Present 
+        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights CreateSubkey -Inheritance 'KeySubKeys' -Ensure Present
 
         $TempAccessRules = @(
             New-Object -TypeName System.Security.AccessControl.RegistryAccessRule `
@@ -1261,18 +1261,18 @@ Describe "$DSCResourceName\Compare-RegistryRule" {
                 )
         )
 
-        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules 
-        
+        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules
+
         $Principal = $TempAcl.Principal
         $Identity = Resolve-Identity -Identity $Principal
         $IdentityRef = [System.Security.Principal.NTAccount]::new($Identity.Name)
         $ACLRules += ConvertTo-RegistryAccessRule -AccessControlList $TempAcl -IdentityRef $IdentityRef
-        
+
         $currentACL = Get-Acl -Path $pathName
         $actualAce = $currentAcl.Access.Where({$_.IdentityReference -eq $Identity.Name})
 
         It "Should have new rule to add" {
-            $testComparison = Compare-RegistryRule -Expected $ACLRules -Actual $actualAce 
+            $testComparison = Compare-RegistryRule -Expected $ACLRules -Actual $actualAce
 
             $testComparison.ToBeRemoved.Rule.Count | Should be $TempAccessRules.Count
             $testComparison.Rules.Count | Should be $TempAcl.AccessControlEntry.Count
@@ -1284,9 +1284,9 @@ Describe "$DSCResourceName\Compare-RegistryRule" {
         }
     }
 
-    Context "Compare-NtfsRule with matching rules and Ensure set to Present" { 
+    Context "Compare-NtfsRule with matching rules and Ensure set to Present" {
         $pathName = "HKCU:\TestKey"
-        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights Delete -Inheritance 'Key' -Ensure Present 
+        $TempAcl = New-RegistryAccessControlList -Principal "Everyone" -ForcePrincipal $false -AccessControlType Allow -RegistryRights Delete -Inheritance 'Key' -Ensure Present
 
         $TempAccessRules = @(
             New-Object -TypeName System.Security.AccessControl.RegistryAccessRule `
@@ -1308,13 +1308,13 @@ Describe "$DSCResourceName\Compare-RegistryRule" {
                 )
         )
 
-        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules 
-        
+        Set-NewTempRegKeyAcl -Path $PathName -AccessRulesToAdd $TempAccessRules
+
         $Principal = $TempAcl.Principal
         $Identity = Resolve-Identity -Identity $Principal
         $IdentityRef = [System.Security.Principal.NTAccount]::new($Identity.Name)
         $ACLRules += ConvertTo-RegistryAccessRule -AccessControlList $TempAcl -IdentityRef $IdentityRef
-        
+
         $currentACL = Get-Acl -Path $pathName
         $actualAce = $currentAcl.Access.Where({$_.IdentityReference -eq $Identity.Name})
 
@@ -1341,7 +1341,7 @@ Describe "$DSCResourceName\ResourceHelper\Resolve-Identity" {
             $Identity.Name | Should be "LOCAL"
             $Identity.SID | Should be "S-1-2-0"
         }
-    
+
         It "Should resolve when input is an SID" {
             $Identity = Resolve-Identity -Identity "S-1-2-0"
 
@@ -1365,6 +1365,48 @@ Describe "$DSCResourceName\ResourceHelper\ConvertTo-SID" {
             $SID = ConvertTo-SID -IdentityReference "BUILTIN\Users"
 
             $SID.Value | Should be "S-1-5-32-545"
-        } 
+        }
+    }
+}
+
+Describe "$DSCResourceName\ResourceHelper\ConvertTo-SidIdentityRegistryAccessRule" {
+    Context "RegistryAccessRule IdentityReference to convert is 'APPLICATION PACKAGE AUTHORITY\ALL APPLICATION PACKAGES'" {
+        It "Should convert 'APPLICATION PACKAGE AUTHORITY\ALL APPLICATION PACKAGES' to S-1-15-2-1 within the RegistryAccessRule" {
+            $TempRegistryAccessRule = New-Object System.Security.AccessControl.RegistryAccessRule `
+                -ArgumentList @(
+                'APPLICATION PACKAGE AUTHORITY\ALL APPLICATION PACKAGES',
+                'ReadKey',
+                'None',
+                'None',
+                'Allow'
+            )
+            $ConvertedRegistryRule = ConvertTo-SidIdentityRegistryAccessRule -Rule $TempRegistryAccessRule
+            $ConvertedRegistryRule.RegistryRights    | Should be 'ReadKey'
+            $ConvertedRegistryRule.AccessControlType | Should be 'Allow'
+            $ConvertedRegistryRule.IdentityReference | Should be 'S-1-15-2-1'
+            $ConvertedRegistryRule.IsInherited       | Should be $false
+            $ConvertedRegistryRule.InheritanceFlags  | Should be 'None'
+            $ConvertedRegistryRule.PropagationFlags  | Should be 'None'
+        }
+    }
+
+    Context "RegistryAccessRule IdentityReference to convert is 'ALL APPLICATION PACKAGES'" {
+        It "Should convert 'ALL APPLICATION PACKAGES' to S-1-15-2-1 within the RegistryAccessRule" {
+            $TempRegistryAccessRule = New-Object System.Security.AccessControl.RegistryAccessRule `
+                -ArgumentList @(
+                    'ALL APPLICATION PACKAGES',
+                    'ReadKey',
+                    'None',
+                    'None',
+                    'Allow'
+                )
+            $ConvertedRegistryRule = ConvertTo-SidIdentityRegistryAccessRule -Rule $TempRegistryAccessRule
+            $ConvertedRegistryRule.RegistryRights    | Should be 'ReadKey'
+            $ConvertedRegistryRule.AccessControlType | Should be 'Allow'
+            $ConvertedRegistryRule.IdentityReference | Should be 'S-1-15-2-1'
+            $ConvertedRegistryRule.IsInherited       | Should be $false
+            $ConvertedRegistryRule.InheritanceFlags  | Should be 'None'
+            $ConvertedRegistryRule.PropagationFlags  | Should be 'None'
+        }
     }
 }


### PR DESCRIPTION
This PR addresses issues highlighted in https://github.com/mcollera/AccessControlDsc/issues/37 and https://github.com/mcollera/AccessControlDsc/issues/38

Modified **RemoveAccessRule** to **RemoveAccessRuleSpecific** to address specific Access Rule Removal.  Also, created a function to create a SID Access Rule when the App Packages and other principals fail to resolve correctly.