### PR TITLE
Release 1.4.3 (#67)

### DIFF
--- a/AccessControlDsc.psd1
+++ b/AccessControlDsc.psd1
@@ -4,7 +4,8 @@
 
 @{
     # Version number of this module.
-    ModuleVersion = '1.4.2'
+    
+    ModuleVersion = '1.4.3'
 
     # ID used to uniquely identify this module
     GUID = 'a544c26f-3f96-4c1e-8351-1604867aafc5'

--- a/DscResources/AccessControlResourceHelper/AccessControlResourceHelper.psm1
+++ b/DscResources/AccessControlResourceHelper/AccessControlResourceHelper.psm1
@@ -52,6 +52,15 @@ function Resolve-Identity
             if ($Identity -match '^S-\d-(\d+-){1,14}\d+$')
             {
                 [System.Security.Principal.SecurityIdentifier]$Identity = $Identity
+
+                # Support for capability sids
+                if ($Identity.Value.StartsWith('S-1-15-3-'))
+                {
+                    return [PSCustomObject]@{
+                        Name = $Identity.Value
+                        SID = $Identity.Value
+                    }
+                }
             }
             else
             {

--- a/DscResources/ActiveDirectoryAccessEntry/ActiveDirectoryAccessEntry.psm1
+++ b/DscResources/ActiveDirectoryAccessEntry/ActiveDirectoryAccessEntry.psm1
@@ -400,7 +400,7 @@ Function Compare-ActiveDirectoryAccessRule
             $_.InheritanceType -eq $referenceObject.InheritanceType -and
             $_.InheritedObjectType -eq $referenceObject.InheritedObjectType -and
             $_.ObjectType -eq $referenceObject.ObjectType -and
-            $_.IdentityReference -eq $referenceObject.IdentityReference
+            $_.IdentityReference.Value -eq $referenceObject.IdentityReference.Value
         })
         if($match.Count -ge 1)
         {
@@ -426,7 +426,7 @@ Function Compare-ActiveDirectoryAccessRule
             $_.InheritanceType -eq $referenceObject.InheritanceType -and
             $_.InheritedObjectType -eq $referenceObject.InheritedObjectType -and
             $_.ObjectType -eq $referenceObject.ObjectType -and
-            $_.IdentityReference -eq $referenceObject.IdentityReference
+            $_.IdentityReference.Value -eq $referenceObject.IdentityReference.Value
         })
         if($match.Count -gt 0)
         {
@@ -444,7 +444,7 @@ Function Compare-ActiveDirectoryAccessRule
             $_.InheritanceType -eq $referenceObject.InheritanceType -and
             $_.InheritedObjectType -eq $referenceObject.InheritedObjectType -and
             $_.ObjectType -eq $referenceObject.ObjectType -and
-            $_.IdentityReference -eq $referenceObject.IdentityReference
+            $_.IdentityReference.Value -eq $referenceObject.IdentityReference.Value
         })
         if($match.Count -eq 0)
         {

--- a/DscResources/ActiveDirectoryAuditRuleEntry/ActiveDirectoryAuditRuleEntry.psm1
+++ b/DscResources/ActiveDirectoryAuditRuleEntry/ActiveDirectoryAuditRuleEntry.psm1
@@ -498,7 +498,7 @@ function Test-ActiveDirectoryAuditRuleMatch
             $_.ObjectType -eq $ReferenceRule.ObjectType -and
             $_.InheritanceType -eq $ReferenceRule.InheritanceType -and
             $_.InheritedObjectType -eq $ReferenceRule.InheritedObjectType -and
-            $_.IdentityReference -eq $ReferenceRule.IdentityReference
+            $_.IdentityReference.Value -eq $ReferenceRule.IdentityReference.Value
         })
     }
     else
@@ -512,7 +512,7 @@ function Test-ActiveDirectoryAuditRuleMatch
             $_.ObjectType -eq $ReferenceRule.ObjectType -and
             $_.InheritanceType -eq $ReferenceRule.InheritanceType -and
             $_.InheritedObjectType -eq $ReferenceRule.InheritedObjectType -and
-            $_.IdentityReference -eq $ReferenceRule.IdentityReference
+            $_.IdentityReference.Value -eq $ReferenceRule.IdentityReference.Value
         })
     }
 }

--- a/DscResources/FileSystemAuditRuleEntry/FileSystemAuditRuleEntry.psm1
+++ b/DscResources/FileSystemAuditRuleEntry/FileSystemAuditRuleEntry.psm1
@@ -518,7 +518,7 @@ function Test-FileSystemAuditRuleMatch
             $_.AuditFlags -eq $ReferenceRule.AuditFlags -and
             $_.InheritanceFlags -eq $ReferenceRule.InheritanceFlags -and
             $_.PropagationFlags -eq $ReferenceRule.PropagationFlags -and
-            $_.IdentityReference -eq $ReferenceRule.IdentityReference
+            $_.IdentityReference.Value -eq $ReferenceRule.IdentityReference.Value
         })
     }
     else
@@ -536,8 +536,7 @@ function Test-FileSystemAuditRuleMatch
             (($_.PropagationFlags.value__ -eq 3 -and $ReferenceRule.PropagationFlags.value__ -in 1..3) -or
             ($_.PropagationFlags.value__ -in 1..3 -and $ReferenceRule.PropagationFlags.value__ -eq 0) -or
             ($_.PropagationFlags.value__ -eq $ReferenceRule.PropagationFlags.value__)) -and
-
-            $_.IdentityReference -eq $ReferenceRule.IdentityReference
+            $_.IdentityReference.Value -eq $ReferenceRule.IdentityReference.Value
         })
     }
 }

--- a/DscResources/NTFSAccessEntry/NTFSAccessEntry.psm1
+++ b/DscResources/NTFSAccessEntry/NTFSAccessEntry.psm1
@@ -631,7 +631,7 @@ function Test-FileSystemAccessRuleMatch
                 $_.InheritanceFlags -eq $ReferenceRule.InheritanceFlags -and
                 $_.PropagationFlags -eq $ReferenceRule.PropagationFlags -and
                 $_.AccessControlType -eq $ReferenceRule.AccessControlType -and
-                $_.IdentityReference -eq $ReferenceRule.IdentityReference
+                $_.IdentityReference.Value -eq $ReferenceRule.IdentityReference.Value
             })
     }
     else
@@ -646,7 +646,7 @@ function Test-FileSystemAccessRuleMatch
                 ($_.PropagationFlags.value__ -in 1..3 -and $ReferenceRule.PropagationFlags.value__ -eq 0) -or
                 ($_.PropagationFlags.value__ -eq $ReferenceRule.PropagationFlags.value__)) -and
                 $_.AccessControlType -eq $ReferenceRule.AccessControlType -and
-                $_.IdentityReference -eq $ReferenceRule.IdentityReference
+                $_.IdentityReference.Value -eq $ReferenceRule.IdentityReference.Value
         })
     }
 }

--- a/DscResources/RegistryAccessEntry/RegistryAccessEntry.psm1
+++ b/DscResources/RegistryAccessEntry/RegistryAccessEntry.psm1
@@ -382,7 +382,7 @@ Function Compare-RegistryRule
                 $_.InheritanceFlags -eq $refrenceObject.InheritanceFlags -and
                 $_.PropagationFlags -eq $refrenceObject.PropagationFlags -and
                 $_.AccessControlType -eq $refrenceObject.AccessControlType -and
-                $_.IdentityReference -eq $refrenceObject.IdentityReference
+                $_.IdentityReference.Value -eq $refrenceObject.IdentityReference.Value
             })
         if ($match.Count -ge 1)
         {
@@ -407,7 +407,7 @@ Function Compare-RegistryRule
             $_.InheritanceFlags -eq $refrenceObject.InheritanceFlags -and
             $_.PropagationFlags -eq $refrenceObject.PropagationFlags -and
             $_.AccessControlType -eq $refrenceObject.AccessControlType -and
-            $_.IdentityReference -eq $refrenceObject.IdentityReference
+            $_.IdentityReference.Value -eq $refrenceObject.IdentityReference.Value
         })
         if($match.Count -eq 0)
         {
@@ -424,7 +424,7 @@ Function Compare-RegistryRule
                 $_.InheritanceFlags -eq $refrenceObject.InheritanceFlags -and
                 $_.PropagationFlags -eq $refrenceObject.PropagationFlags -and
                 $_.AccessControlType -eq $refrenceObject.AccessControlType -and
-                $_.IdentityReference -eq $refrenceObject.IdentityReference
+                $_.IdentityReference.Value -eq $refrenceObject.IdentityReference.Value
             })
         if ($match.Count -gt 0)
         {


### PR DESCRIPTION
* Active directory access entry (#28)

* initial ActiveDirectoryAccessEntry resource

* updates to ActiveDirectoryAccessEntry resource

* ActiveDirectoryAccessEntry unit test; resource fixes

* updated readme; added example; mof fixes

* version rev

* AuditRule fixes

* Updated issue with ACLRules not always being an array when trying to add additional objects. Updated issue where Expected.Rules might only be a single object while trying to call a Where extension method. (#31)

* Rights guid (#32)

* Updated ActiveDirectoryAccessEntry example with a valid ADRights value Refactored Get-SchemaGuidId helper function to
Get-DelegationRightsGuid so it returns schemaGuids and rightsGuids

* typo corrections

* Update Get-SchemaObjectName to resolve SchemaGuids and RightsGuids

* Added $guidmap to Get-SchemaObjectName

* Added $rootDse to Get-SchemaObjectName

* Changes RegistryAccessEntry to correctly remove specific ACEs from ACLs and gracefully handle the App Packages Principal, Issues #37 and #38 (#39)

* Added ConvertTo-SidIdentityReg... funct. to addr app packages transation

* Mod. Rule/Expected foreach to correct rule input for ConvertTo-SidId...

* modified RemoveAccessRule to RemoveAccessRuleSpecific to addr. issue #38

* added Set-RegistryRightsAclAllAppPackages function

* added test for Set-RegistryRightsAclAllAppPackages function.

* updated test to hanlde deny scenario

* updated formatting and defined output type for New-TempAclItem

* Update ReadMe to include new version and changes. (#42)

* Added ConvertTo-SidIdentityReg... funct. to addr app packages transation

* Mod. Rule/Expected foreach to correct rule input for ConvertTo-SidId...

* modified RemoveAccessRule to RemoveAccessRuleSpecific to addr. issue #38

* added Set-RegistryRightsAclAllAppPackages function

* added test for Set-RegistryRightsAclAllAppPackages function.

* updated test to hanlde deny scenario

* updated formatting and defined output type for New-TempAclItem

* updated readme.md

* NTFSAccessControlEntry Resource Bug Fix (#45)

* Added ConvertTo-SidIdentityReg... funct. to addr app packages transation

* Mod. Rule/Expected foreach to correct rule input for ConvertTo-SidId...

* modified RemoveAccessRule to RemoveAccessRuleSpecific to addr. issue #38

* added Set-RegistryRightsAclAllAppPackages function

* added test for Set-RegistryRightsAclAllAppPackages function.

* updated test to hanlde deny scenario

* updated formatting and defined output type for New-TempAclItem

* updated readme.md

* updated Test/Set to use Get/SetAccessControl Methods, vs. Get/Set-Acl

* updated readme.md with bug fix information

* NTFSAccessControl Refactoring and fix for bug #46 - NTFSAccessControlEntry - False Positive Test Bug (#47)

* Added ConvertTo-SidIdentityReg... funct. to addr app packages transation

* Mod. Rule/Expected foreach to correct rule input for ConvertTo-SidId...

* modified RemoveAccessRule to RemoveAccessRuleSpecific to addr. issue #38

* added Set-RegistryRightsAclAllAppPackages function

* added test for Set-RegistryRightsAclAllAppPackages function.

* updated test to hanlde deny scenario

* updated formatting and defined output type for New-TempAclItem

* updated readme.md

* updated Test/Set to use Get/SetAccessControl Methods, vs. Get/Set-Acl

* updated readme.md with bug fix information

* pre-test run, new feature, w/force wipe acl

* updated NTFSAccessEntry.psm1 to clear existing currentacl

* refactoring changes.

* bug fix #46 and code refactoring with added Write-CustomVerbose function

* updated README.md with bug fix information

* updated fs rights logic to ensure test runs when permissions are less.

* Update ModuleVersion in Module Manifest psd1 (#48)

* Added ConvertTo-SidIdentityReg... funct. to addr app packages transation

* Mod. Rule/Expected foreach to correct rule input for ConvertTo-SidId...

* modified RemoveAccessRule to RemoveAccessRuleSpecific to addr. issue #38

* added Set-RegistryRightsAclAllAppPackages function

* added test for Set-RegistryRightsAclAllAppPackages function.

* updated test to hanlde deny scenario

* updated formatting and defined output type for New-TempAclItem

* updated readme.md

* updated Test/Set to use Get/SetAccessControl Methods, vs. Get/Set-Acl

* updated readme.md with bug fix information

* pre-test run, new feature, w/force wipe acl

* updated NTFSAccessEntry.psm1 to clear existing currentacl

* refactoring changes.

* bug fix #46 and code refactoring with added Write-CustomVerbose function

* updated README.md with bug fix information

* updated fs rights logic to ensure test runs when permissions are less.

* incremented the ModuleVersion in module manifest psd1.

* Fix for Feature Request #49 - ObjectType Parameter in ActiveDirectoryAuditRuleEntry (#50)

* refactor work

* daily commit for refactor work

* add support for objecttype and central localization text

* updated code to be in line with style guide lines.

* updated NTFSAccessEntry with import localization based on PSUICulture

* updated/refactor tests to handle objecttype parameter

* Finish Get Method

* Test method first version

* 1st version Set method

* Test Set working Get broken

* Everything works. Needs tests

* Started unit tests

* Unit tests done

* Add integration tests but not verified

* Correct typo in FileSystemAuidtRuleEntry unit test

* Updater readme and examples FileSystemAuditRuleEntry

* Updated schema files Moved base class to top of file to pass PSScriptAnalyzer rule

* Update tests

* Update testHelper path

* Resolve PR descrepancies

* Updated module version

* put comments on get/test/set functions

* Style updates

* style corrections

* AccessControlDSC v1.4.0.0 is throwing error while trying to set permission to a folder for the group "ALL APPLICATION PACKAGES" and "ALL RESTRICTED APPLICATION PACKAGES" (#59)

* workaround for Win32 API bug App Package

* added new line to the EoF

* updated appveyor.yml

* updated appveyor.yml

* updated appveyor.yml to use Pester 4.10.1

* update tests to satisfy code coverage

* updated module manifest with symantic versioning

* fixed NTFS PowerShell v7 compat

* Capabilitysids (#65)

* Merge Dev into Master Build 1.1.0.0 (#33)

* Active directory access entry (#28)

* initial ActiveDirectoryAccessEntry resource

* updates to ActiveDirectoryAccessEntry resource

* ActiveDirectoryAccessEntry unit test; resource fixes

* updated readme; added example; mof fixes

* version rev

* AuditRule fixes

* Updated issue with ACLRules not always being an array when trying to add additional objects. Updated issue where Expected.Rules might only be a single object while trying to call a Where extension method. (#31)

* Rights guid (#32)

* Updated ActiveDirectoryAccessEntry example with a valid ADRights value Refactored Get-SchemaGuidId helper function to
Get-DelegationRightsGuid so it returns schemaGuids and rightsGuids

* typo corrections

* Update Get-SchemaObjectName to resolve SchemaGuids and RightsGuids

* Added $guidmap to Get-SchemaObjectName

* Added $rootDse to Get-SchemaObjectName

* Add inheritance options to NtfsAccessEntry (#34)

It's easier to get these values from the Readme, than going through code each time.

* Release 10/6/2021

* Support for capability SIDS

Co-authored-by: Brett Slaski <brettski@yahoo.com>
Co-authored-by: Jason Ryberg <jason@ryberg.dev>
Co-authored-by: Matthew Collera <Matthew.Collera@microsoft.com>

Co-authored-by: Reggie Gibson <31147354+regedit32@users.noreply.github.com>
Co-authored-by: Brian Gouldman <32549363+bgouldman@users.noreply.github.com>
Co-authored-by: Jason Walker <walkerjason@live.com>
Co-authored-by: Brian Wilhite <bcwilhite@live.com>
Co-authored-by: Jason Walker <jwalker@microsoft.com>
Co-authored-by: Chase Wilson <31453523+chasewilson@users.noreply.github.com>
Co-authored-by: Brett Slaski <brettski@yahoo.com>
Co-authored-by: Jason Ryberg <jason@ryberg.dev>
Co-authored-by: Matthew Collera <Matthew.Collera@microsoft.com>